### PR TITLE
README fix docker build command typo

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -38,7 +38,7 @@ You can automatically deploy a local docker wordpress site in 5 minutes using th
 git clone https://github.com/kassambara/wordpress-docker-compose
 cd wordpress-docker-compose
 # Build and start installation
-docker-compose up -d --build
+docker-compose up -d build
 ```
 
 Visit your site at http://localhost and your database via phpMyAdmin at http://localhost:8080. 
@@ -62,12 +62,12 @@ Default identification for the phpMyAdmin interface:
 # Stop and remove containers
 docker-compose down
 # Build, and start the wordpress website
-docker-compose up -d --build
+docker-compose up -d build
 # Reset everything
 docker-compose down
 rm -rf certs/* certs-data/* logs/nginx/* mysql/* wordpress/*
 ```
-  
+
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ using the following commands:
 git clone https://github.com/kassambara/wordpress-docker-compose
 cd wordpress-docker-compose
 # Build and start installation
-docker-compose up -d --build
+docker-compose up -d build
 ```
 
 Visit your site at <http://localhost> and your database via phpMyAdmin
@@ -53,7 +53,7 @@ Default identification for the phpMyAdmin interface:
 # Stop and remove containers
 docker-compose down
 # Build, and start the wordpress website
-docker-compose up -d --build
+docker-compose up -d build
 # Reset everything
 docker-compose down
 rm -rf certs/* certs-data/* logs/nginx/* mysql/* wordpress/*


### PR DESCRIPTION
Hi.

I've just seen typos in `docker build` commands so I decided a quick fix wouldn't take too long.