### PR TITLE
wp core install fails as the blog title is not escaped.

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ DATABASE_PASSWORD=password
 DATABASE_USER=root
 
 # 3/ For wordpress auto-install and auto-configuration -------------------
-WORDPRESS_WEBSITE_TITLE="My Blog"
+WORDPRESS_WEBSITE_TITLE="My\ Blog"
 
 # URL
 WORDPRESS_WEBSITE_URL="http://localhost"


### PR DESCRIPTION
Make does not escape spaces so will treat My Blog as two separate parameters which causes the wp cli command to fail. Long term solution is to put in place some sort of substitution to escape values in variables before use.