### PR TITLE
Misc fixes for wp-cli and autoinstall on Ubuntu WSL2.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,10 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME}_wpcli
     volumes:
       - ${WORDPRESS_DATA_DIR:-./wordpress}:/var/www/html
+    environment:
+      - WORDPRESS_DB_HOST=${WORDPRESS_DB_HOST:-mysql}
+      - WORDPRESS_DB_USER=${DATABASE_USER:-root}
+      - WORDPRESS_DB_PASSWORD=${DATABASE_PASSWORD:-password}
     working_dir: /var/www/html
 
 # Check availability of essential services

--- a/wpcli/Makefile
+++ b/wpcli/Makefile
@@ -5,7 +5,7 @@ configure:
 	@echo "⚙️ Configuring Wordpress parameters..."
 	wp core install \
 		--url=${WORDPRESS_WEBSITE_URL_WITHOUT_HTTP} \
-		--title=$(WORDPRESS_WEBSITE_TITLE) \
+		--title="$(WORDPRESS_WEBSITE_TITLE)" \
 		--admin_user=${WORDPRESS_ADMIN_USER} \
 		--admin_password=${WORDPRESS_ADMIN_PASSWORD} \
 		--admin_email=${WORDPRESS_ADMIN_EMAIL}


### PR DESCRIPTION
wpcli could not seem to connect as the environment variables were not set.

E.g. I had this in my ~/.bash_profile

```alias wp="docker-compose run --rm wpcli"```

Then tried to run 
```wp post list```

Which previously showed
Error: Error establishing a database connection.

Confirmed by echoing the constants defined in the wp-config.php