### PR TITLE
fixed permissions issue with docker-compose and space in title name

### DIFF
--- a/wpcli/Dockerfile
+++ b/wpcli/Dockerfile
@@ -13,6 +13,7 @@ RUN chmod +x /wait
 # Add Makefile to scripts dir
 ADD Makefile entrypoint.sh /scripts/
 RUN chmod +x /scripts/entrypoint.sh
+RUN chmod 775 /scripts/Makefile
 
 ENTRYPOINT [ "/scripts/entrypoint.sh" ]
 USER 33:33

--- a/wpcli/Makefile
+++ b/wpcli/Makefile
@@ -5,7 +5,7 @@ configure:
 	@echo "⚙️ Configuring Wordpress parameters..."
 	wp core install \
 		--url=${WORDPRESS_WEBSITE_URL_WITHOUT_HTTP} \
-		--title=$(WORDPRESS_WEBSITE_TITLE) \
+		--title="$(WORDPRESS_WEBSITE_TITLE)" \
 		--admin_user=${WORDPRESS_ADMIN_USER} \
 		--admin_password=${WORDPRESS_ADMIN_PASSWORD} \
 		--admin_email=${WORDPRESS_ADMIN_EMAIL}


### PR DESCRIPTION
Permission issue in /scripts/Makefile prevented container from deploying and having a space in the title name caused a "Error: Too many positional arguments: Blog"