### PR TITLE
Update wordpress avalible to reach localhost's db & fix wp_cli keep alive

### DIFF
--- a/docker-compose-onlinehost.yml
+++ b/docker-compose-onlinehost.yml
@@ -86,11 +86,17 @@ services:
     build: ./wpcli/
     image: wpcli
     container_name: ${COMPOSE_PROJECT_NAME}_wpcli
+    command: tail -f /dev/null
     volumes:
       - ${WORDPRESS_DATA_DIR:-./wordpress}:/var/www/html
     working_dir: /var/www/html
-    networks:
-        - ${COMPOSE_PROJECT_NAME}_default
+    environment:
+      WORDPRESS_DB_HOST: host.docker.internal:3306
+      WORDPRESS_DB_USER: ${DATABASE_USER}
+      WORDPRESS_DB_PASSWORD: ${DATABASE_PASSWORD}
+      WORDPRESS_DB_NAME: ${COMPOSE_PROJECT_NAME}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 # Check availability of essential services
   healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     restart: always
     ports:
         - 80:80
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   mysql:
     image: mariadb:${MARIADB_VERSION:-latest}


### PR DESCRIPTION
wp-cli example
```
docker exec wordpress_wpcli wp --info
docker exec wordpress_wpcli wp user list
```